### PR TITLE
ble_hs_stop.c: Prevent duplicate entries in ble_hs_stop_listeners.

### DIFF
--- a/nimble/host/src/ble_hs_stop.c
+++ b/nimble/host/src/ble_hs_stop.c
@@ -172,7 +172,16 @@ static void
 ble_hs_stop_register_listener(struct ble_hs_stop_listener *listener,
                               ble_hs_stop_fn *fn, void *arg)
 {
+    struct ble_hs_stop_listener *node;
     BLE_HS_DBG_ASSERT(fn != NULL);
+
+    // Check, if the to-be-inserted list/node is already in the list
+    // If it is, do NOT insert it.
+    SLIST_FOREACH(node, &ble_hs_stop_listeners, link) {
+        if (listener == node) {
+            return;
+        }
+    }
 
     listener->fn = fn;
     listener->arg = arg;


### PR DESCRIPTION
Under circumstances not fully clear sometimes duplicate list elements are added to the `list ble_hs_stop_listeners`. If that happens, the function `ble_hs_stop_done()` never terminates.
This PR adds a check into `ble_hs_stop_register_listener()` if a to-be-added node/sublist already exist in the list and the it does not add this element. While this is anyhow a good test, it should not be needed in the MicroPython environment.